### PR TITLE
Feat: control thread and n*worker thread(#32)

### DIFF
--- a/include/job.c
+++ b/include/job.c
@@ -1,0 +1,40 @@
+#include "job.h"
+
+void init_queue(JobQueue *queue) {
+    queue->head = NULL;
+    queue->tail = NULL;
+    pthread_mutex_init(&queue->mutex, NULL);
+    pthread_cond_init(&queue->cond, NULL);
+}
+
+void push(JobQueue* queue, Job* job) {
+    Node* new_node = (Node *)malloc(sizeof(Node));
+
+    new_node->job = job;
+    new_node->next = NULL;
+    pthread_mutex_lock(&queue->mutex);
+    if (queue->tail) {
+        queue->tail->next = new_node;
+    } else {
+        queue->head = new_node;
+    }
+    queue->tail = new_node;
+    pthread_cond_signal(&queue->cond);
+    pthread_mutex_unlock(&queue->mutex);
+}
+
+Job* pop(JobQueue* queue) {
+    pthread_mutex_lock(&queue->mutex);
+    while (queue->head == NULL) {
+        pthread_cond_wait(&queue->cond, &queue->mutex);
+    }
+    Node* node = queue->head;
+    Job* job = node->job;
+    queue->head = node->next;
+    if (queue->head == NULL) {
+        queue->tail = NULL;
+    }
+    free(node);
+    pthread_mutex_unlock(&queue->mutex);
+    return job;
+}

--- a/include/job.h
+++ b/include/job.h
@@ -1,0 +1,28 @@
+#ifndef __JOB_H__
+#define __JOB_H__
+
+#include "message.h"
+#include <pthread.h>
+
+typedef struct{
+    int client_socket;
+    _Message* message;
+} Job;
+
+typedef struct Node{
+    Job* job;
+    struct Node* next;
+} Node;
+
+typedef struct{
+    Node* head;
+    Node* tail;
+    pthread_mutex_t mutex;
+    pthread_cond_t cond;
+} JobQueue;
+
+void init_queue(JobQueue* queue);
+void push(JobQueue* queue, Job* job);
+Job* pop(JobQueue* queue);
+
+#endif

--- a/include/logging.c
+++ b/include/logging.c
@@ -1,5 +1,7 @@
 #include "logging.h"
 
+#include <stdio.h>
+#include <stdlib.h>
 #include <stdarg.h>
 #include <sys/time.h>
 #include <time.h>
@@ -33,4 +35,37 @@ int print_log(FILE* file, const int line, const char* func, const LogLevel level
     va_end(ap);
     fflush(file);
     return char_num;
+}
+
+char* get_file_path(const char* file_home, ...){
+    va_list args;
+    va_start(args, file_home);
+
+    va_list args_copy;
+    va_copy(args_copy, args);
+    size_t length = compute_length(file_home, args_copy);
+    va_end(args_copy);
+
+    char* ret = (char*)malloc((length + 1) * sizeof(char));
+    if (!ret) {
+        return NULL;
+    }
+
+    strcpy(ret, file_home);
+    const char* str;
+    while ((str = va_arg(args, const char*)) != NULL) {
+        strcat(ret, str);
+    }
+
+    va_end(args);
+    return ret;
+}
+
+size_t compute_length(const char* first, va_list args) {
+    size_t length = strlen(first);
+    const char* str;
+    while ((str = va_arg(args, const char*)) != NULL) {
+        length += strlen(str);
+    }
+    return length;
 }

--- a/include/logging.h
+++ b/include/logging.h
@@ -8,6 +8,7 @@
 #define log_info(file, fmt, args...) print_log(file, __LINE__, __func__, LOG_LEVEL_INFO, fmt, ## args)
 #define log_error(file) print_log(file, __LINE__, __func__, LOG_LEVEL_ERROR, "%s\n", strerror(errno))
 #define log(file, level, fmt, args...) print_log(file, __LINE__, __func__, level, fmt, ## args)
+#define LOG_FILE_HOME "./log/"
 
 typedef enum{
     LOG_LEVEL_INFO,
@@ -17,5 +18,6 @@ typedef enum{
 extern const char* logtostr[];
 
 int print_log(FILE* file, const int line, const char *func, const LogLevel level, const char *format, ... );
-
+char* get_file_path(const char* file_home, ...);
+size_t compute_length(const char* first, va_list args);
 #endif

--- a/include/message.c
+++ b/include/message.c
@@ -19,23 +19,30 @@ void make_response(_Response* response, ResponseStatus status, char* data){
     response->data = (char*)calloc(response->header.data_size, sizeof(char));
     strncpy(response->data, data, response->header.data_size);
 }
-}
 
 
 void free_message(_Message* message){
     if(message){
-        if(message->file_name)
+        if(message->file_name){
             free(message->file_name);
-        if(message->content)
+            message->file_name = NULL;
+        }
+        if(message->content){
             free(message->content);
+            message->content = NULL;
+        }
         free(message);
+        message = NULL;
     }
 }
 
 void free_response(_Response* response){
     if(response){
-        if(response->data)
+        if(response->data){
             free(response->data);
+            response->data = NULL;
+        }
         free(response);
+        response = NULL;
     }
 }

--- a/include/message.c
+++ b/include/message.c
@@ -46,3 +46,37 @@ void free_response(_Response* response){
         response = NULL;
     }
 }
+
+ssize_t recv_full(int sockfd, void *buffer, size_t length) {
+    size_t total_received = 0;
+    ssize_t bytes_received;
+
+    while (total_received < length) {
+        bytes_received = recv(sockfd, (char*)buffer + total_received, length - total_received, 0);
+        if (bytes_received < 0) {
+            perror("recv error");
+            return -1;
+        } else if (bytes_received == 0) {
+            break;
+        }
+
+        total_received += bytes_received;
+    }
+
+    return total_received;
+}
+
+ssize_t send_full(int sockfd, const void *buffer, size_t length) {
+    size_t total_sent = 0;
+    ssize_t bytes_sent;
+
+    while (total_sent < length) {
+        bytes_sent = send(sockfd, (char*)buffer + total_sent, length - total_sent, 0);
+        if (bytes_sent < 0) {
+            perror("send error");
+            return -1;
+        }
+        total_sent += bytes_sent;
+    }
+    return total_sent;
+}

--- a/include/message.c
+++ b/include/message.c
@@ -14,10 +14,28 @@ MessageType get_message_type(char* input){
 }
 
 void make_response(_Response* response, ResponseStatus status, char* data){
-    response->body.status = status;
+    response->header.status = status;
     response->header.data_size = strlen(data)+1;
-    response->body.data = (char*)calloc(response->header.data_size, sizeof(char));
-    strncpy(response->body.data, data, response->header.data_size);
+    response->data = (char*)calloc(response->header.data_size, sizeof(char));
+    strncpy(response->data, data, response->header.data_size);
 }
 }
 
+
+void free_message(_Message* message){
+    if(message){
+        if(message->file_name)
+            free(message->file_name);
+        if(message->content)
+            free(message->content);
+        free(message);
+    }
+}
+
+void free_response(_Response* response){
+    if(response){
+        if(response->data)
+            free(response->data);
+        free(response);
+    }
+}

--- a/include/message.h
+++ b/include/message.h
@@ -15,20 +15,16 @@ typedef enum{
 typedef struct{
     size_t file_name_size;
     size_t content_size;
-	// FD 매핑정보
+    size_t data_size;
+    MessageType type;
+    long offset;
+	int length;
 } MessageHeader;
 
 typedef struct{
-    MessageType type;
-	char* file_name;
-    long offset;
-	int length;
 	char* content;
-} MessageBody;
-
-typedef struct{
-	MessageHeader header;
-	MessageBody body;
+	char* file_name;
+    MessageHeader header;
 } _Message;
 
 typedef enum{
@@ -38,18 +34,16 @@ typedef enum{
 
 typedef struct{
     size_t data_size;
+    ResponseStatus status;
 } ResponseHeader;
 
 typedef struct{
-    ResponseStatus status;
 	char* data;
-} ResponseBody;
-
-typedef struct{
 	ResponseHeader header;
-	ResponseBody body;
 } _Response;
 
 MessageType get_message_type(char* input);
 void make_response(_Response* response, ResponseStatus status, char* data);
+void free_message(_Message* message);
+void free_response(_Response* response);
 #endif

--- a/include/message.h
+++ b/include/message.h
@@ -3,6 +3,7 @@
 
 #include <string.h>
 #include <stdlib.h>
+#include <sys/socket.h>
 
 typedef enum{
 	GETALL,
@@ -46,4 +47,6 @@ MessageType get_message_type(char* input);
 void make_response(_Response* response, ResponseStatus status, char* data);
 void free_message(_Message* message);
 void free_response(_Response* response);
+ssize_t recv_full(int sockfd, void *buffer, size_t length);
+ssize_t send_full(int sockfd, const void *buffer, size_t length);
 #endif

--- a/src/client.c
+++ b/src/client.c
@@ -123,6 +123,7 @@ _Message* parse_command(char* input_buffer){
     char* upper_token = to_upper_case(token, strlen(token));
     message->header.type = get_message_type(upper_token);
     free(upper_token);
+    upper_token = NULL;
 
     if(message->header.type == UNKNOWN){
         syntax_error("Undefined Command");

--- a/src/server.c
+++ b/src/server.c
@@ -145,6 +145,7 @@ void* cthr_func(void* arg){
     }
     close(listening_socket);
     free(queue);
+    queue = NULL;
     return NULL;
 }
 
@@ -211,11 +212,13 @@ void process_job(Job* job){
             file_path = get_file_path(FILE_HOME, message->file_name, NULL);
             command_delete(message, file_path, response);
             free(file_path);
+            file_path = NULL;
             break;
         case GET: case PUT:
             file_path = get_file_path(FILE_HOME, message->file_name, NULL);
             sync_file_io(message, file_path, response);
             free(file_path);
+            file_path = NULL;
             break;
         default:
             log(log_file, LOG_LEVEL_ERROR, "%s\n", "Invalid command");
@@ -328,6 +331,7 @@ void command_getall(_Response* response){
         }
         total_size += strlen(dir->d_name)+1;
         free(path);
+        path = NULL;
     }
     response->header.data_size = total_size;
     response->data = (char*)malloc(response->header.data_size * sizeof(char));
@@ -349,6 +353,7 @@ void command_getall(_Response* response){
         strcat(response->data, dir->d_name);
         strcat(response->data, "\n");
         free(path);
+        path = NULL;
     }
     closedir(dp);
 }
@@ -396,6 +401,7 @@ FILE* init_server(){
     char* log_file_name = get_file_path(LOG_FILE_HOME, "server_", pid_str, NULL);
     log_file = fopen(log_file_name, "a+");
     free(log_file_name);
+    log_file_name = NULL;
     return log_file;
 }
 
@@ -405,13 +411,9 @@ void* wthr_func(void* arg) {
         Job* job = pop(queue);
         if (job != NULL) {
             process_job(job);
-            if(job->message->file_name)
-                free(job->message->file_name);
-            if(job->message->content)
-                free(job->message->content);
-            if(job->message)
-                free(job->message);
+            free_message(job->message);
             free(job);
+            job=NULL;
         }
     }
 }

--- a/src/server.c
+++ b/src/server.c
@@ -8,20 +8,23 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdarg.h>
+#include <pthread.h>
+#include <sys/ioctl.h>
 
 #include "../include/message.h"
 #include "../include/logging.h"
+#include "../include/job.h"
 
 #define PORT 8080
 #define MAX_BUF_SIZE 1024
 #define FILE_HOME "./file/"
 #define LOG_FILE_HOME "./log/"
+#define WTHR_NUM 5
 
 FILE* log_file;
 
-void connect_client();
 void sync_file_io(_Message* message, char* file_path, _Response* response);
-void exec_command(int new_socket);
+_Message* create_message(int new_socket);
 void command_get(FILE* fp, int length, _Response* response);
 void command_put(FILE** fp, _Message* message, char* file_path, _Response* response);
 FILE* open_and_seek_file(_Message* message, char* file_path);
@@ -30,23 +33,40 @@ void command_getall(_Response* response);
 char* get_file_path(const char* file_home, ...);
 size_t compute_length(const char* first, va_list args);
 FILE* init_server();
+void* cthr_func(void* arg);
+void* wthr_func(void* arg);
+void process_job(Job* job);
+void send_response(Job* job, _Response* response);
 
 int main(int argc, char const* argv[]){
     log_file = init_server();
     log_info(log_file, "Starting server...\n");
 
-	connect_client();
+    pthread_t cthr;
+
+    pthread_create(&cthr, NULL, cthr_func, NULL);
+    pthread_join(cthr, NULL);
 
 	log_info(log_file, "Shutdown server...\n");
 	fclose(log_file);
 	return 0;
 }
 
-void connect_client(){
+void* cthr_func(void* arg){
     int listening_socket, client_socket;
 	struct sockaddr_in addr;
 	int opt = 1;
 	socklen_t addrlen = sizeof(addr);
+	fd_set read_fds, copy_rdfds;
+	struct timeval timeout;
+
+    pthread_t wthr[WTHR_NUM];
+    JobQueue* queue = (JobQueue*)malloc(sizeof(JobQueue));
+    init_queue(queue);
+
+    for(int i=0; i < WTHR_NUM; i++){
+        pthread_create(&wthr[i], NULL, wthr_func, queue);
+    }
 
 	if((listening_socket = socket(AF_INET, SOCK_STREAM,0))<0){
         log_error(log_file);
@@ -58,6 +78,11 @@ void connect_client(){
         exit(EXIT_FAILURE);
 	}
 
+    if(ioctl(listening_socket, FIONBIO, (char*)&opt) < 0){
+        log_error(log_file);
+        exit(EXIT_FAILURE);
+    }
+
 	memset(&addr, 0, sizeof(addr));
 	addr.sin_family = AF_INET;
 	addr.sin_addr.s_addr = INADDR_ANY;
@@ -65,138 +90,156 @@ void connect_client(){
 
 	if (bind(listening_socket, (struct sockaddr*)&addr, sizeof(addr)) < 0){
 	    log_error(log_file);
-		exit(EXIT_FAILURE);	
+		exit(EXIT_FAILURE);
 	}
 
 	if(listen(listening_socket, SOMAXCONN) < 0){
 		log_error(log_file);
-		exit(EXIT_FAILURE);	
+		exit(EXIT_FAILURE);
 	}
 
-	while((client_socket = accept(listening_socket, (struct sockaddr*)&addr, &addrlen)) >= 0 ){
-        printf("\nConnected to %s\n", inet_ntoa(addr.sin_addr));
-        exec_command(client_socket);
+    FD_ZERO(&read_fds);
+    FD_SET(listening_socket, &read_fds);
+    int max_sd = listening_socket;
 
-        printf("\nConnection to %s closed.\n", inet_ntoa(addr.sin_addr));
-        close(client_socket);
-	}
+    while (1) {
+        copy_rdfds = read_fds;
 
-    close(listening_socket);
-
-	if(client_socket < 0){
-        log_error(log_file);
-        exit(EXIT_FAILURE);
+        if ((select(max_sd + 1, &copy_rdfds, NULL, NULL, NULL) < 0) && (errno != EINTR)) {
+            log_error(log_file);
+            break;
+        }
+        for(int i = 0; i <= max_sd; i++){
+            if (FD_ISSET(i, &copy_rdfds)) {
+                if(i == listening_socket){
+                    if ((client_socket = accept(listening_socket, (struct sockaddr*)&addr, &addrlen)) < 0) {
+                        log_error(log_file);
+                        continue;
+                    }
+                    FD_SET(client_socket, &read_fds);
+                    if (client_socket > max_sd) {
+                        max_sd = client_socket;
+                    }
+                    printf("\nConnected\n");
+                }else{
+                    _Message* message = create_message(i);
+                    if(!message){
+                        close(i);
+                        FD_CLR(i, &read_fds);
+                        continue;
+                    }
+                    printf("\n===========\n");
+                    print_message(message);
+                    printf("\n===========\n");
+                    Job* job = (Job*)malloc(sizeof(Job));
+                    if(!job){
+                        perror("job malloc error");
+                        continue;
+                    }
+                    job->client_socket = i;
+                    job->message = message;
+                    push(queue, job);
+                }
+            }
+        }
     }
+    close(listening_socket);
+    free(queue);
+    return NULL;
 }
 
-void exec_command(int client_socket){
+_Message* create_message(int client_socket){
     ssize_t valread;
+
+    _Message* message = (_Message*)calloc(1, sizeof(_Message));
+    if(!message){
+        perror("message calloc error");
+        return NULL;
+    }
+
+    valread = recv(client_socket, &message->header, sizeof(message->header), 0);
+    if(valread < 0){
+        perror("recv header error");
+        return NULL;
+    }else if(valread == 0){
+        shutdown(client_socket, SHUT_RDWR);
+        printf("\nUnconnected\n");
+        return NULL;
+    }
+
+    if(message->header.file_name_size > 0){
+        message->file_name = (char*)calloc(message->header.file_name_size, sizeof(char));
+        if (!message->file_name) {
+            perror("Failed to allocate file name memory");
+            return NULL;
+        }
+        valread = recv(client_socket, message->file_name, message->header.file_name_size, 0);
+        if(valread < 0){
+            perror("recv file name error");
+            return NULL;
+        }
+    }
+
+    if(message->header.content_size > 0){
+        message->content = (char*)calloc(message->header.content_size, sizeof(char));
+        if (!message->content) {
+            perror("Failed to allocate content memory");
+            return NULL;
+        }
+        valread = recv(client_socket, message->content, message->header.content_size, 0);
+        if(valread < 0){
+            perror("recv content error");
+            return NULL;
+        }
+    }
+    return message;
+}
+
+void process_job(Job* job){
     char* file_path = NULL;
-
-	while(1){
-        _Message* message = (_Message*)calloc(1, sizeof(_Message));
-        if(!message){
-            perror("message calloc error");
+    _Message* message = job->message;
+    _Response* response = (_Response*)calloc(1, sizeof(_Response));
+    if(!response){
+        perror("response calloc error");
+        return;
+    }
+    switch(message->header.type){
+        case GETALL:
+            command_getall(response);
             break;
-        }
-
-        valread = recv(client_socket, &message->header, sizeof(message->header), 0) ;
-        if(valread < 0){
-            perror("recv header error");
-            continue;
-        }else if(valread == 0){
-            shutdown(client_socket, SHUT_RDWR);
+        case DELETE:
+            file_path = get_file_path(FILE_HOME, message->file_name, NULL);
+            command_delete(message, file_path, response);
+            free(file_path);
             break;
-        }
-
-        valread = recv(client_socket, &message->body, sizeof(MessageBody), 0);
-        if(valread < 0){
-            perror("recv body error");
+        case GET: case PUT:
+            file_path = get_file_path(FILE_HOME, message->file_name, NULL);
+            sync_file_io(message, file_path, response);
+            free(file_path);
             break;
-        }
-
-        if(message->header.file_name_size > 0){
-            message->body.file_name = (char*)calloc(message->header.file_name_size, sizeof(char));
-            if (!message->body.file_name) {
-                perror("Failed to allocate file name memory");
-                break;
-            }
-            valread = recv(client_socket, message->body.file_name, message->header.file_name_size, 0);
-            if(valread < 0){
-                perror("recv name error");
-                break;
-            }
-        }
-
-        if(message->header.content_size > 0){
-            message->body.content = (char*)calloc(message->header.content_size, sizeof(char));
-            if (!message->body.content) {
-                perror("Failed to allocate content memory");
-                break;
-            }
-            valread = recv(client_socket, message->body.content, message->header.content_size, 0);
-            if(valread < 0){
-                perror("recv content error");
-                break;
-            }
-        }
-
-        _Response* response = (_Response*)calloc(1, sizeof(_Response));
-        if(!response){
-            perror("response calloc error");
+        default:
+            log(log_file, LOG_LEVEL_ERROR, "%s\n", "Invalid command");
+            make_response(response, ERROR, "Invalid command");
             break;
-        }
+    }
+    send_response(job, response);
+}
 
-        switch(message->body.type){
-            case GETALL:
-                command_getall(response);
-                break;
-            case DELETE:
-                file_path = get_file_path(FILE_HOME, message->body.file_name, NULL);
-                command_delete(message, file_path, response);
-                free(file_path);
-                break;
-            case GET: case PUT:
-                file_path = get_file_path(FILE_HOME, message->body.file_name, NULL);
-                sync_file_io(message, file_path, response);
-                free(file_path);
-                break;
-            default:
-                log(log_file, LOG_LEVEL_ERROR, "%s\n", "Invalid command");
-                make_response(response, ERROR, "Invalid command");
-                break;
-        }
-
-        send(client_socket, &response->header, sizeof(response->header), 0);
-        send(client_socket, &response->body, sizeof(response->body), 0);
-        if(response->header.data_size > 0){
-            send(client_socket, response->body.data, response->header.data_size, 0);
-        }
-
-        if(message->header.file_name_size>0){
-            free(message->body.file_name);
-        }
-        if(message->body.content>0){
-            free(message->body.content);
-        }
-        if(!message)
-            free(message);
-
-        if(response->header.data_size > 0){
-            free(response->body.data);
-        }
-        if(!response)
-            free(response);
-	}
+void send_response(Job* job, _Response* response){
+    send(job->client_socket, &response->header, sizeof(response->header), 0);
+    if(response->header.data_size > 0){
+        send(job->client_socket, response->data, response->header.data_size, 0);
+    }
+    free_response(response);
 }
 
 void sync_file_io(_Message* message, char* file_path, _Response* response){
 	FILE* fp = open_and_seek_file(message, file_path);
 
-	if(message->body.type == PUT){
+	if(message->header.type == PUT){
         command_put(&fp, message, file_path, response);
-    }else if(message->body.type == GET){
-        command_get(fp, message->body.length, response);
+    }else if(message->header.type == GET){
+        command_get(fp, message->header.length, response);
     }
 	if(fp){
 	    fclose(fp);
@@ -212,7 +255,7 @@ void command_get(FILE* fp, int length, _Response* response){
 
     char* ret = NULL;
     int length_left = length;
-    response->body.data = (char*)malloc(length * sizeof(char));
+    response->data = (char*)malloc(length * sizeof(char));
 
     while(length_left > 0 && !feof(fp)){
         char buffer[MAX_BUF_SIZE] = {0};
@@ -228,12 +271,12 @@ void command_get(FILE* fp, int length, _Response* response){
         }
 
         if(!strcmp(ret,"\n")) continue;
-        strcat(response->body.data, ret);
+        strcat(response->data, ret);
         length_left -= strlen(ret);
         if(buffer[strlen(ret)-1]=='\n') length_left++;
     }
-    strcat(response->body.data, "\0");
-    response->header.data_size = strlen(response->body.data);
+    strcat(response->data, "\0");
+    response->header.data_size = strlen(response->data)+1;
 }
 
 void command_put(FILE** fp, _Message* message, char* file_path, _Response* response){
@@ -241,7 +284,7 @@ void command_put(FILE** fp, _Message* message, char* file_path, _Response* respo
         log_info(log_file, "Creating file...\n");
         *fp = fopen(file_path, "w+");
     }
-    fputs(message->body.content, *fp);
+    fputs(message->content, *fp);
     make_response(response, SUCCESS, "File written successfully.\n");
 }
 
@@ -250,7 +293,7 @@ FILE* open_and_seek_file(_Message* message, char* file_path){
 
     if(fp){
         log_info(log_file, "The file is opened\n");
-        fseek(fp, message->body.offset, SEEK_SET);
+        fseek(fp, message->header.offset, SEEK_SET);
     }
 
     return fp;
@@ -287,8 +330,8 @@ void command_getall(_Response* response){
         free(path);
     }
     response->header.data_size = total_size;
-    response->body.data = (char*)malloc(response->header.data_size * sizeof(char));
-    if(!response->body.data){
+    response->data = (char*)malloc(response->header.data_size * sizeof(char));
+    if(!response->data){
         log_error(log_file);
         return;
     }
@@ -303,6 +346,8 @@ void command_getall(_Response* response){
 
         strcat(response->body.data, dir->d_name);
         strcat(response->body.data, "\n");
+        strcat(response->data, dir->d_name);
+        strcat(response->data, "\n");
         free(path);
     }
     closedir(dp);
@@ -352,4 +397,21 @@ FILE* init_server(){
     log_file = fopen(log_file_name, "a+");
     free(log_file_name);
     return log_file;
+}
+
+void* wthr_func(void* arg) {
+    JobQueue* queue = (JobQueue*)arg;
+    while (1) {
+        Job* job = pop(queue);
+        if (job != NULL) {
+            process_job(job);
+            if(job->message->file_name)
+                free(job->message->file_name);
+            if(job->message->content)
+                free(job->message->content);
+            if(job->message)
+                free(job->message);
+            free(job);
+        }
+    }
 }


### PR DESCRIPTION
## 지난 코드리뷰와 달라진 점
  - 메시지 데이터 동적 메모리 할당
  - 메시지 프로토콜의 헤더와 메시지 형태
  - 1:1 recv/send 아닌 socker input/output buffer 크기에 따라 recv/send 수 달라질 수 있어 받은 송수신한 데이터의 길이로 recv/send 수 조정
  - client단 logging 추가
 
## 추가 부분

 - Option 1. Frame 추가구현
 - step 6. 1 cthr + 1 wthr
    -  7-1. queue + lock을 이용해서 job 넘기기
 - step 8. 1 cthr + N wthr
 
### 구현 내용
- server 시작시 control thread 생성
- 클라이언트와 소켓연결시 accept으로 블로킹되어 socket I/O를 논블로킹으로 변경
- Event-driven 아키텍처를 구현하기 위해 select로 fd의 이벤트 감지
- 이벤트 감지시 cthr fd가 server socket인지 판단 -> accept/ job생성하여 queue에 넣음
- worker thread가 하나의 Queue를 감지하고 있다가 경쟁적으로 job처리 후 db로 request 보냄
